### PR TITLE
AWS EC2 배포 및 환경 변수 설정 #6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+ALLOWED_ORIGINS=http://localhost:5173
+VITE_API_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # AI Prompts
 .github/Prompts
 copilot-instructions.md
+.github/instructions
 
 # templates
 docs/decisions/000-ADR-template.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Secrets & Keys
+*.pem
+*.key
+
 # AI Prompts
 .github/Prompts
 copilot-instructions.md

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,12 @@ from starlette.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 
-origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
+ # CORS 허용 IP 목록
+origins = []
+
+for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(","):
+    if origin.strip():
+        origins.append(origin.strip())
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,11 @@
+import os
 from fastapi import FastAPI
 from datetime import datetime, timezone
 from starlette.middleware.cors import CORSMiddleware
 
 app = FastAPI()
 
-origins = [
-    "http://localhost:5173"
-]
+origins = os.getenv("ALLOWED_ORIGINS", "http://localhost:5173").split(",")
 
 app.add_middleware(
     CORSMiddleware,

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,8 @@ services:
     build: ./backend
     ports:
       - "8000:8000"
+    environment:
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:5173}
     volumes:
       - ./backend:/app
   
@@ -11,7 +13,7 @@ services:
     ports:
       - "5173:5173"
     environment:
-      - VITE_API_URL=http://localhost:8000
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:8000}
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/docs/meetings/2026-03/2026-03-05-EC2 인스턴스 생성 및 네트워크 설정.md
+++ b/docs/meetings/2026-03/2026-03-05-EC2 인스턴스 생성 및 네트워크 설정.md
@@ -1,0 +1,41 @@
+# 2026-03-05-EC2 인스턴스 생성 및 네트워크 설정
+
+## Summary (회의 요약)
+AWS 콘솔에서 EC2 인스턴스를 생성하고 Security Group, Elastic IP를 설정하여 외부 접근 가능한 서버 환경을 구축함. Key Pair 보관 방식을 정비하고 `copilot-instructions.md`에 AWS 인프라 정보를 추가함.
+
+## Key Decisions (주요 결정 사항)
+
+### AMI로 Ubuntu Server 24.04 LTS 선택
+- **내용:** Amazon Linux 2023 대신 Ubuntu Server 24.04 LTS 선택
+- **이유:** Docker 관련 공식 문서 및 튜토리얼이 Ubuntu 기준으로 작성된 경우가 많아 학습 자료가 풍부하고, `apt` 기반이라 검색 결과를 그대로 사용 가능함
+
+### Key Pair 파일 보관 위치
+- **내용:** `.pem` 파일을 전용 폴더에 보관
+- **이유:** 전용 디렉토리에 집중 관리하여 분실 방지 및 경로 일관성 유지
+
+## 작업 내용
+
+### EC2 인스턴스 생성
+- **AMI:** Ubuntu Server 24.04 LTS (ami-0f***)
+- **Instance type:** t2.micro (Free tier)
+- **Security Group 인바운드 규칙:**
+- **Storage:** 8 GiB (gp3)
+
+### Elastic IP 할당 및 연결
+- Elastic IP 할당
+- EC2 인스턴스에 Associate 완료
+- EC2 Public IPv4 address가 Elastic IP로 고정됨
+
+### 보안 정비
+- `.gitignore`에 `*.pem`, `*.key` 추가하여 Key Pair 파일이 Git에 커밋되지 않도록 설정
+- `copilot-instructions.md`에 `## AWS 인프라 정보` 섹션 추가 (새 채팅 세션에서도 EC2 접속 정보 참조 가능)
+
+## TIL (느낀 점)
+- 처음으로 AWS EC2 인스턴스를 생성했다! 그리고 이번에 Elastic IP라는 것도 처음 사용해 보았다
+- 키파일은 안전하게 보관해둬야지. 실무에서는 어떻게 관리하는 지 좀 궁금하다
+
+## Action Items (다음 할 일)
+- [ ] SSH 접속 확인
+- [ ] EC2에 Docker 설치
+- [ ] EC2에 Docker Compose 설치
+- [ ] 프로젝트 클론 (`git clone`)

--- a/docs/meetings/2026-03/2026-03-08-copilot-instructions 개선 & EC2 SSH 접속 및 Docker 설치.md
+++ b/docs/meetings/2026-03/2026-03-08-copilot-instructions 개선 & EC2 SSH 접속 및 Docker 설치.md
@@ -1,0 +1,61 @@
+# 2026-03-08-copilot-instructions 개선 & EC2 SSH 접속 및 Docker 설치
+
+## Summary (회의 요약)
+CLAUDE.md 작성 요령을 조사하고 `copilot-instructions.md`를 개선함. 이후 EC2 인스턴스에 SSH로 첫 접속에 성공하고, Docker 공식 apt repository 방식으로 Docker를 설치함.
+
+## Key Decisions (주요 결정 사항)
+
+### Commands / Architecture 섹션 추가
+- **내용:** 파일 상단부에 실행 명령어와 디렉토리 역할 설명 섹션을 추가함.
+- **이유:** Boris Cherny(Claude Code 창시자)의 CLAUDE.md 철학에 따르면 "코드에서 추론 불가능한 정보"만 작성하는 것이 핵심. 명령어와 아키텍처는 AI가 코드만 봐서는 알 수 없는 대표적인 정보임.
+
+### Karpathy 행동 원칙 통합 및 범위 한정
+- **내용:** Andrej Karpathy의 4원칙(Think Before Coding / Simplicity First / Surgical Changes / Goal-Driven Execution)을 AI 가이드라인에 추가하되, "예외 조건으로 코드를 작성할 때만 적용"으로 범위를 명시적으로 한정함.
+- **이유:** 이 프로젝트는 학습 중심 개발이므로 AI가 코드를 직접 작성하는 경우가 제한적. Karpathy 원칙이 항상 활성화되면 학습 가이드라인과 충돌할 수 있음.
+
+### AI 가이드라인을 AI 직접 명령 언어로 재작성
+- **내용:** 기존 "AI에게 요청 불가능한 것" 형식(사용자 가이드 언어)을 "사용자가 구현 요청 시 아래 순서를 따라라" 형식(AI 직접 지시 언어)으로 전환함.
+- **이유:** AI는 자신에게 직접 말하는 명령에 더 일관되게 반응함. 사용자 언어로 쓰인 규칙은 AI가 자신의 행동 지침으로 해석하지 않을 수 있음.
+
+### 응답 패턴 예시 및 예외 조건 명시
+- **내용:** 구현 요청 / 에러 / 코드 리뷰 3가지 유형별 응답 예시와, 코드 직접 제시가 허용되는 4가지 예외 조건을 추가함.
+- **이유:** 경계가 없으면 AI가 매번 다르게 판단함. 구체적인 예시와 예외 조건이 있어야 일관된 학습 보조 역할을 수행할 수 있음.
+
+### GitHub Issue/PR 상세 템플릿 간소화
+- **내용:** 본문에 인라인으로 포함되어 있던 상세 템플릿을 요약 규칙만 남기는 형식으로 간소화함.
+- **이유:** 상세 템플릿은 이미 `.github/prompts/` 파일에 별도로 관리되고 있어 중복이었음. 중복 제거로 약 60줄 감소.
+
+### Must Follow / Don't 섹션 추가
+- **내용:** 코드 리뷰 섹션에 "Must Follow"와 "Don't" 항목을 명시적으로 분리하여 추가함.
+- **이유:** 기존에는 필수/금지 사항이 파일 전체에 산재해 있어 AI가 우선순위를 파악하기 어려웠음.
+
+## Blockers & Solutions (블로커 & 해결책)
+
+### TIL 작성 방식 변경 — AI 질문 후 사용자 답변 기반 작성
+- **내용:** `meeting-summary.md`의 TIL 섹션을 AI가 직접 작성하던 방식에서, AI가 세션 내용 기반 질문을 제시하고 사용자 답변을 받아 작성하는 방식으로 변경함. "TIL 질문 단계" 지침을 파일 하단에 별도 섹션으로 추가함.
+- **이유:** AI가 작성한 TIL은 실제 느낀 점이 아닌 작업 요약에 가까워졌음. 사용자의 언어로 작성된 TIL이 미래의 나를 위한 기록에 더 부합함.
+
+### 회의록 동일 날짜 파일 추가 방식 — 기존 섹션에 병합
+- **내용:** 같은 날짜에 여러 세션이 있으면 별도 섹션(`---`)으로 분리하지 않고 기존 Summary/Key Decisions/Blockers/Action Items 섹션에 내용을 병합함.
+- **이유:** 날짜 기준 파일 하나에 그날의 모든 작업이 응집되어야 일관성 있는 회의록이 됨.
+
+- **문제:** Windows에서 SSH 접속 시 `.pem` 키 파일 권한 에러 발생
+  ```
+  WARNING: UNPROTECTED PRIVATE KEY FILE!
+  Bad permissions. Try removing permissions for user: NT AUTHORITY\Authenticated Users
+  ```
+- **해결:** `icacls` 명령어로 권한 재설정
+  1. 상속 제거: `icacls <키파일> /inheritance:r`
+  2. Authenticated Users 제거: `icacls <키파일> /remove "NT AUTHORITY\Authenticated Users"`
+  3. 현재 사용자에게만 읽기 권한 부여: `icacls <키파일> /grant "$($env:USERNAME):R"`
+
+- **문제:** `sudo apt install docker-ce` 실행 시 `Package 'docker-ce' has no installation candidate` 에러
+- **해결:** Docker GPG 키 및 apt 저장소를 먼저 등록한 뒤 재설치. 설치 전 저장소 등록 단계(`Set up Docker's apt repository`)가 선행되어야 함
+
+## TIL (느낀 점)
+- 역시.. PowerShell만의 독특한 명령어가 가끔은 불편할 때가 있다. Linux와 병합해줬으면 좋겠어ㅋㅋㅋ
+- Linux 학습 때 배운 apt 저장소 개념을 실전에서 복습할 수 있어서 좋았다.
+
+## Action Items (다음 할 일)
+- [ ] EC2에 Docker Compose 설치
+- [ ] EC2 서버 환경 설정 후 진행한 회의록을 한번에 커밋하기

--- a/docs/meetings/2026-03/2026-03-14-EC2 배포 및 copilot-instructions 구조 개선.md
+++ b/docs/meetings/2026-03/2026-03-14-EC2 배포 및 copilot-instructions 구조 개선.md
@@ -32,6 +32,22 @@ EC2 서버 환경 설정을 완료하고(Docker, Docker Compose 설치, 프로�
 1. **로컬/EC2 환경을 분리:** 지금까지 로컬하고 EC2 환경을 어떻게 분리해서 관리하는 지 몰랐는데, 이번에 직접 EC2에 작업하면서 로컬과 EC2를 분리해서 개발하는 흐름을 알게 되었다.
 2. **외부에서 접속 시 API 연결이 안 됐던 이유:** localhost는 로컬의 IP를 나타내고, 외부에서는 퍼블릭 IP를 사용해야 한다는 점을 이해했다.
 3. 지금까지 간단한 작업이었지만 배포할 때는 항상 기분이 짜릿한 거 같다! 스마트폰으로도 접속이 되어서 기쁘다!
+4. **AI 시대의 개발 방식 변화:** `copilot-instructions.md`를 생각보다 자주 수정하게 된다. 대학생 때는 코드 짜는 것에 대부분의 시간을 보냈는데, 요즘은 AI 관련 파일이나 지시사항을 수정하는 데에도 시간을 보내게 되었다. 시대가 바뀌었다는 것이 느껴진다.
+
+## Key Decisions (주요 결정 사항) — copilot-instructions 구조 개선
+
+### instruction 파일 분리
+- **내용:** `copilot-instructions.md` 단일 파일(340줄)을 5개 파일로 분리함.
+  - `copilot-instructions.md` — 항상 로드되는 핵심 컨텍스트 (Commands, 아키텍처 제약, 워크플로우 트리거)
+  - `.github/instructions/ai-pair-programming.instructions.md` (`applyTo: **`) — 페어 프로그래밍 원칙, 코딩 행동 원칙
+  - `.github/instructions/python-backend.instructions.md` (`applyTo: backend/**`) — Python/FastAPI 규칙, DB 설계
+  - `.github/instructions/svelte-frontend.instructions.md` (`applyTo: frontend/src/**`) — Svelte/TypeScript 규칙
+  - `.github/instructions/git-workflow.instructions.md` (`applyTo: **`) — 커밋/PR/Issue 가이드라인
+- **이유:** CLAUDE.md 작성 요령(wikidocs.net/333419) 참고. AI가 추측 가능한 내용(프로젝트 개요, 기술 스택)은 제거하고, `applyTo` 패턴으로 필요한 파일 작업 시에만 로드되도록 최적화함.
+
+### 코딩 행동 원칙 적용 범위 명확화
+- **내용:** 코딩 행동 원칙(Simplicity First, Surgical Changes 등)은 예외 조건 여부와 관계없이 **항상 적용**으로 변경. 코드 직접 제시 예외 조건은 구문 오류(typo)와 사용자 명시적 허용 2가지로 축소.
+- **이유:** 기존에는 "예외 조건으로 코드를 작성할 때만"이라고 명시되어 있어 힌트를 줄 때도 단순하게 줘야 한다는 의도가 불분명했음.
 
 ## Action Items (다음 할 일)
 - [ ] README에 배포 환경 URL 추가

--- a/docs/meetings/2026-03/2026-03-14-EC2 배포 및 환경 변수 설정.md
+++ b/docs/meetings/2026-03/2026-03-14-EC2 배포 및 환경 변수 설정.md
@@ -1,0 +1,38 @@
+# 2026-03-14-EC2 배포 및 환경 변수 설정
+
+## Summary (회의 요약)
+EC2 서버 환경 설정을 완료하고(Docker, Docker Compose 설치, 프로젝트 클론), CORS 및 API URL 환경 변수화를 통해 외부에서 Backend와 Frontend 모두 접근 가능한 상태를 만듦.
+
+## Key Decisions (주요 결정 사항)
+
+### CORS 및 API URL을 환경 변수로 관리
+- **내용:** `ALLOWED_ORIGINS`와 `VITE_API_URL`을 `compose.yaml`에 하드코딩하지 않고 `.env` 파일로 분리하여 관리함. `compose.yaml`에서는 `${VAR:-기본값}` 문법으로 기본값(localhost)을 지정함.
+- **이유:** 로컬 개발 환경과 EC2 배포 환경이 다른 주소를 사용하기 때문. 코드 변경 없이 환경별로 다른 값을 주입하기 위함.
+
+### `develop` 브랜치로 EC2 클론
+- **내용:** `git clone -b develop` 으로 develop 브랜치 코드를 EC2에 클론함.
+- **이유:** ADR 007 전략에 따라 Phase 1 완료 시 `develop` → `main` 병합 예정이므로, 현 단계에서는 `main`에 병합하기 이름. 배포 작업은 `develop` 기준으로 진행함.
+
+### `.env.example` 관리 방식
+- **내용:** `.env`는 `.gitignore`로 차단하고, `.env.example`에는 `localhost` 기본값만 담아 GitHub에 공개함.
+- **이유:** 실제 서버 IP 등 민감 정보를 저장소에 노출하지 않기 위함. 개발자가 `.env.example`을 보고 `.env`를 만들 수 있도록 가이드 역할 제공.
+
+## Blockers & Solutions (블로커 & 해결책)
+
+- **문제:** `docker compose up -d` 실행 시 `permission denied while trying to connect to the Docker socket` 에러 발생.
+- **해결:** `sudo docker compose up -d`로 실행.
+
+- **문제:** Frontend에서 "Failed to load service status" 에러 발생.
+- **해결:** Backend의 CORS `origins`에 `http://localhost:5173`만 있어 EC2 IP에서의 요청이 차단된 것이 원인. `os.getenv("ALLOWED_ORIGINS")` 방식으로 환경 변수화하여 해결.
+
+- **문제:** `compose.yaml`에서 `VITE_API_URL=http://localhost:8000`으로 설정된 채 배포되어 브라우저가 EC2 대신 사용자 PC로 API 요청을 보냄.
+- **해결:** `VITE_API_URL`도 환경 변수로 분리하고, EC2의 `.env`에 Public IP를 직접 설정.
+
+## TIL (느낀 점)
+1. **로컬/EC2 환경을 분리:** 지금까지 로컬하고 EC2 환경을 어떻게 분리해서 관리하는 지 몰랐는데, 이번에 직접 EC2에 작업하면서 로컬과 EC2를 분리해서 개발하는 흐름을 알게 되었다.
+2. **외부에서 접속 시 API 연결이 안 됐던 이유:** localhost는 로컬의 IP를 나타내고, 외부에서는 퍼블릭 IP를 사용해야 한다는 점을 이해했다.
+3. 지금까지 간단한 작업이었지만 배포할 때는 항상 기분이 짜릿한 거 같다! 스마트폰으로도 접속이 되어서 기쁘다!
+
+## Action Items (다음 할 일)
+- [ ] README에 배포 환경 URL 추가
+- [ ] `feature/#6-aws-deploy` → `develop` PR 작성 및 Merge

--- a/docs/meetings/2026-03/2026-03-15-PR 코드 리뷰 반영 및 리스트 컴프리헨션 학습.md
+++ b/docs/meetings/2026-03/2026-03-15-PR 코드 리뷰 반영 및 리스트 컴프리헨션 학습.md
@@ -1,0 +1,21 @@
+# 2026-03-15-PR 코드 리뷰 반영 및 리스트 컴프리헨션 학습
+
+## Summary (회의 요약)
+PR #9 코드 리뷰 내용을 검토하고, `ALLOWED_ORIGINS` 파싱 로직의 공백/빈 항목 방어 처리를 적용함. 리스트 컴프리헨션 문법을 학습한 후, 기초 `for`문으로 재작성하여 가독성을 높임.
+
+## Key Decisions (주요 결정 사항)
+
+### ALLOWED_ORIGINS 파싱 로직 개선
+- **내용:** `os.getenv("ALLOWED_ORIGINS", ...).split(",")` 결과에 `strip()`과 빈 문자열 필터링(`if origin.strip()`)을 적용함. 리스트 컴프리헨션 대신 기초 `for`문으로 작성함.
+- **이유:** CORS는 origin을 문자열로 정확히 비교하기 때문에, `.env`의 공백이나 trailing comma로 인해 의도치 않게 CORS가 실패하는 상황을 방어하기 위함. 기초 `for`문이 더 읽기 쉬워 선택함.
+
+## Blockers & Solutions (블로커 & 해결책)
+- 특이사항 없음.
+
+## TIL (느낀 점)
+- **리스트 컴프리헨션:** 처음 접하는 문법이라 이해하기 어려웠다. 기초 `for`문으로 풀어 쓰니 코드를 이해하게 되었다. 동작에는 차이가 없으니 보기 편한 코드로 수정했다.
+- **파이썬 필터:** `if origin.strip()`이 필터 역할을 한다는 것을 통해 파이썬 필터에 대해 아직 공부가 부족하다는 것을 알게 되었다.
+
+## Action Items (다음 할 일)
+- [ ] EC2에서 변경 사항 정상 동작 확인 (`feature/#6-aws-deploy` 브랜치 기준)
+- [ ] `feature/#6-aws-deploy` → `develop` PR 작성 및 Merge


### PR DESCRIPTION
## 개요
AWS EC2 인스턴스를 생성하고 네트워크를 설정한 뒤, CORS 및 API URL을 환경 변수로 분리하여 외부에서 Backend와 Frontend 모두 접근 가능한 상태로 배포함.

## 관련 이슈 & 브랜치
- 이슈: #6
- 브랜치: `feature/#6-aws-deploy` → `develop`

## 변경 사항
- EC2 인스턴스 생성 및 네트워크 설정
- Elastic IP 할당 및 연결
- EC2 서버 환경 설정 (Docker, Docker Compose 설치, 프로젝트 클론)
- `ALLOWED_ORIGINS`, `VITE_API_URL`을 환경 변수로 분리 (`compose.yaml` + `.env`)
- `.env.example` 추가 및 `.gitignore`에 `.env` 등록
- `copilot-instructions.md` 단일 파일을 5개 instruction 파일로 분리
- 배포 과정 회의록 작성 (2026-03-05, 2026-03-08, 2026-03-14)

## 테스트 방법
1. EC2 인스턴스 시작
2. SSH 접속 후 `.env` 파일 생성 (`.env.example` 참고, EC2 Public IP 입력)
3. `sudo docker compose up -d`
4. `http://xx.xx.xx.xx:8000/health` — Backend 응답 확인
5. `http://5xx.xx.xx.xx:5173` — Frontend 접속 확인

## 참고 사항
- EC2는 상시 운영하지 않으므로 README에 배포 URL은 추가하지 않음
- ADR 005 참고: 현 단계는 AWS GUI로 직접 배포. 향후 Terraform으로 전환 예정